### PR TITLE
iOS chrome(구글) Footer Email Button 디자인 이슈 해결

### DIFF
--- a/src/component/Footer/atoms/Mail.tsx
+++ b/src/component/Footer/atoms/Mail.tsx
@@ -25,6 +25,7 @@ const Email = styled.button`
   ${({ theme }) => theme.typographies.body4};
   color: ${({ theme }) => theme.colors.gray2};
   text-decoration: underline;
+  text-underline-offset: 2px;
   &:hover {
     color: ${({ theme }) => theme.colors.gray1};
   }

--- a/src/globalStyle/InitStyle.ts
+++ b/src/globalStyle/InitStyle.ts
@@ -43,6 +43,7 @@ a{
 button {
   border: none;
   background: none;
+  margin: 0;
   padding: 0;
   cursor: pointer;
 }

--- a/src/globalStyle/InitStyle.ts
+++ b/src/globalStyle/InitStyle.ts
@@ -48,7 +48,7 @@ button {
   cursor: pointer;
 }
 
-body{
+*, body {
   font-family: 'Pretendard', sans-serif;
 }
 `;


### PR DESCRIPTION
- **iOS chrome 브라우저/Google 검색 엔진**에서 아래 사진처럼 이메일 line-height가 맞지 않는 이슈 발생
-> Button 태그 자체의 글로벌 스타일에 `margin: 0` 추가 
- **공통**: Global Font 적용 후 Text-decoration이 @의 높낮이때문에 잘리는 이슈 발생
-> `text-underline-offset`으로 해결

![image](https://github.com/mju-likelion/inception/assets/90755664/525e029f-292f-444f-946b-2a8bf7006633)
![image](https://github.com/mju-likelion/inception/assets/90755664/e0272d1b-2051-40f6-abba-0233b2c55f65)