### PR TITLE
디자인 디테일 피드백 반영

### DIFF
--- a/src/component/calendar/atom/Count.tsx
+++ b/src/component/calendar/atom/Count.tsx
@@ -13,16 +13,16 @@ export const Count = ({ count, activeStatus = 'default' }: Props) => {
 };
 
 const Wrapper = styled.h1<{ $activeStatus: ActiveStatus }>`
+  width: 16px;
+  height: 16px;
+  ${({ theme }) => theme.typographies.body5};
   position: absolute;
   bottom: 2px;
   right: 2px;
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 16px;
-  height: 16px;
   border-radius: 100%;
-  font-size: 11px;
   background-color: ${({ $activeStatus, theme }) => {
     if ($activeStatus === 'default') {
       return theme.colors.gray1;
@@ -37,4 +37,10 @@ const Wrapper = styled.h1<{ $activeStatus: ActiveStatus }>`
       return theme.colors.white;
     }
   }};
+
+  @media ${({ theme }) => theme.size.web} {
+    width: 24px;
+    height: 24px;
+    ${({ theme }) => theme.typographies.body2.regular};
+  }
 `;

--- a/src/component/calendar/atom/GridItem.tsx
+++ b/src/component/calendar/atom/GridItem.tsx
@@ -98,10 +98,16 @@ const Wrapper = styled.button<{
         height: 100%;
         align-items: start;
         p {
-          width: 20px;
-          height: 20px;
+          ${({ theme }) => theme.typographies.body3}
           margin-top: 2px;
           margin-left: 4px;
+        }
+        @media ${({ theme }) => theme.size.web} {
+          p {
+            ${({ theme }) => theme.typographies.body1.regular}
+            margin-top: 2px;
+            margin-left: 4px;
+          }
         }
       }
       border-top: 2px solid ${({ theme }) => theme.colors.gray1};

--- a/src/component/calendar/molecules/CalendarHeader.tsx
+++ b/src/component/calendar/molecules/CalendarHeader.tsx
@@ -1,4 +1,3 @@
-import { Title } from '@/component/@share';
 import { styled } from 'styled-components';
 import { NextButton, BackButton } from '@/component/@share/atom';
 import { DateRangeLimit } from '@/types';
@@ -16,9 +15,7 @@ export const CalendarHeader = ({
 }: Props) => {
   return (
     <Wrapper>
-      <Title ag="Title2" color="gray1">
-        {`${currentDate[0]}년 ${+currentDate[1]}월`}
-      </Title>
+      <DateTitle>{`${currentDate[0]}년 ${+currentDate[1]}월`}</DateTitle>
       <ButtonWrapper>
         <BackButton
           isDisabled={dateRangeLimit.start}
@@ -43,6 +40,14 @@ const Wrapper = styled.div`
     width: 180px;
     display: flex;
     align-items: center;
+  }
+`;
+
+const DateTitle = styled.h1`
+  color: ${({ theme }) => theme.colors.gray1};
+  ${({ theme }) => theme.typographies.title2}
+  @media ${({ theme }) => theme.size.web} {
+    ${({ theme }) => theme.typographies.title1}
   }
 `;
 

--- a/src/component/calendar/organisms/calendar.tsx
+++ b/src/component/calendar/organisms/calendar.tsx
@@ -4,7 +4,6 @@ import {
   Date as DateComponent,
   DateHeader,
 } from '@/component/calendar/molecules';
-import { useWeekCount } from '@/hooks';
 import {
   ActiveStatus,
   CalendarData,
@@ -153,8 +152,6 @@ const CreateMode = ({
     getCalendarData(minDate[0], minDate[1])
   );
 
-  const [weekCount, setWeekCount] = useWeekCount(minDate);
-
   const [dateRangeLimit, setDateRangeLimit] = useState<DateRangeLimit>(
     checkLimitDate(currentDate, minDate, maxDate)
   );
@@ -197,13 +194,11 @@ const CreateMode = ({
     ) {
       setCalendar((prev) => prev.concat(changedCalendar));
     }
-
-    setWeekCount([changedYear, changedMonth]);
   };
 
   /** @TODO GridFooter는 result === on 일때만 보여준다. GridHeader, GridFooter는 molecules로 관리해야될 것 같다. */
   return (
-    <Grid $weekCount={weekCount}>
+    <Grid>
       <GridHeader>
         <CalendarHeader
           currentDate={currentDate}
@@ -236,7 +231,6 @@ const ResultMode = ({
   checkLimitDate,
 }: ResultModeProps) => {
   const [currentDate, setCurrentDate] = useState(minDate.slice(0, 2));
-  const [weekCount, setWeekCount] = useWeekCount(minDate);
   const [calendar, setCalendar] = useState<CalendarData[]>(() =>
     getCalendarData(minDate[0], minDate[1], promiseResult)
   );
@@ -267,8 +261,6 @@ const ResultMode = ({
     ) {
       setCalendar((prev) => prev.concat(changedCalendar));
     }
-
-    setWeekCount([changedYear, changedMonth]);
   };
 
   const handleClickDate = (date?: string) => {
@@ -287,7 +279,7 @@ const ResultMode = ({
   };
 
   return (
-    <Grid $weekCount={weekCount}>
+    <Grid>
       <GridHeader>
         <CalendarHeader
           currentDate={currentDate}
@@ -313,19 +305,11 @@ const ResultMode = ({
   );
 };
 
-const Grid = styled.div<{ $weekCount: number }>`
+const Grid = styled.div`
   display: flex;
   flex-direction: column;
 
-  aspect-ratio: ${({ $weekCount }) => {
-    if ($weekCount === 6) {
-      return '1/1.3125';
-    } else if ($weekCount === 5) {
-      return '1/1.15';
-    } else {
-      return '1/0.9875';
-    }
-  }};
+  aspect-ratio: 1/1.15;
 
   min-width: 320px;
   max-width: 500px;

--- a/src/component/calendar/organisms/calendar.tsx
+++ b/src/component/calendar/organisms/calendar.tsx
@@ -299,7 +299,9 @@ const ResultMode = ({
       </>
 
       <GridFooter>
-        <ButtonSmall>일정 수정</ButtonSmall>
+        <FooterRightWrapper>
+          <ButtonSmall>일정 수정</ButtonSmall>
+        </FooterRightWrapper>
       </GridFooter>
     </Grid>
   );
@@ -330,4 +332,9 @@ const GridFooter = styled.div`
   justify-content: end;
   height: 71px;
   align-items: center;
+`;
+
+const FooterRightWrapper = styled.div`
+  margin-top: 15px;
+  margin-bottom: 16px;
 `;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -31,7 +31,11 @@ export const Home = () => {
           />
         </TitleBoxContainer>
         <CalendarBox>
-          <Calendar viewType="create" />
+          <Calendar
+            minDate="2015-02-01"
+            maxDate="2030-01-01"
+            viewType="create"
+          />
           <HorizontalRule />
         </CalendarBox>
         <TimePickerBox>


### PR DESCRIPTION
### ing
-

### done

- 달력 4,5,6줄 마다 상단 요소들이 위아래로 들쑥날쑥
    - 달력 줄 수에 따라 달력 비율이 달라지고있다.
    - 비율을 1/1.15로 통일하여 해결
- 그리고 다 땡땽이 띄워주면 안되고 기준(2명이상 선택) 되어있는건지 확인하기
    - 구현 예정
- 결과확인 페이지에서 선택이 아니라 가장 많이 겹친 날짜에 민트색인거 확인하기
    - 구현 예정
- CalendarDay 폰트 다름, web일때 사이즈 다름
- 카운터 UI가 십의 자리일 떄 가운데 정렬이 안됨
  - 폰트 문제 폰트 해결 버전 확인

### todo

모바일/웹 달력 컴포넌트 폰트 사이즈

- 캘린더 컴포넌트 Web상태일 때 ‘2023년 6월’ 텍스트 크기 다름
- 일~월 영문 텍스트 폰트 다름, web 상태일때 폰트 크기 다름
- 결과페이지에서 (특히 모바일) 캘린더 컴포넌투의 일정수정과 하단의 Info 컴포넌트 간격이 다름