### PR TITLE
로그인 및 코드입력 페이지에서  푸터 고정

### DIFF
--- a/src/component/@share/template/LoginMasterTemplate.tsx
+++ b/src/component/@share/template/LoginMasterTemplate.tsx
@@ -112,6 +112,7 @@ const WrapButton = styled.div`
   display: flex;
   justify-content: center;
   margin: 200px 0px 100px 0px;
+  //푸터고정 = calc (뷰크기(vh) - (헤더를 제외한 내부콘텐츠 및 마진 + 푸터))
   min-height: calc(100vh - 744px);
 
   @media ${({ theme }) => theme.size.tablet} {

--- a/src/component/@share/template/LoginMasterTemplate.tsx
+++ b/src/component/@share/template/LoginMasterTemplate.tsx
@@ -77,7 +77,6 @@ const WrapContents = styled.div`
   flex-direction: column;
   justify-content: center;
   margin-top: 30px;
-
   @media ${({ theme }) => theme.size.tablet} {
     align-items: center;
     margin-top: 60px;
@@ -113,11 +112,14 @@ const WrapButton = styled.div`
   display: flex;
   justify-content: center;
   margin: 200px 0px 100px 0px;
+  min-height: calc(100vh - 744px);
 
   @media ${({ theme }) => theme.size.tablet} {
     margin: 158px 0px 100px 0px;
+    min-height: calc(100vh - 710px);
   }
   @media ${({ theme }) => theme.size.web} {
     margin: 220px 0px 100px 0px;
+    min-height: calc(100vh - 808px);
   }
 `;

--- a/src/pages/CodeSubmitPage.tsx
+++ b/src/pages/CodeSubmitPage.tsx
@@ -105,7 +105,7 @@ const WrapButton = styled.div`
   min-height: calc(100vh - 744px);
 
   @media ${({ theme }) => theme.size.tablet} {
-    margin: 100px 0px 100px 0px;
+    margin: 100px 0px;
     min-height: calc(100vh - 691px);
   }
 

--- a/src/pages/CodeSubmitPage.tsx
+++ b/src/pages/CodeSubmitPage.tsx
@@ -101,12 +101,15 @@ const WrapButton = styled.div`
   display: flex;
   justify-content: center;
   margin: 200px 0px 100px 0px;
+  min-height: calc(100vh - 744px);
 
   @media ${({ theme }) => theme.size.tablet} {
     margin: 100px 0px 100px 0px;
+    min-height: calc(100vh - 691px);
   }
 
   @media ${({ theme }) => theme.size.web} {
     margin-top: 220px;
+    min-height: calc(100vh - 847px);
   }
 `;

--- a/src/pages/CodeSubmitPage.tsx
+++ b/src/pages/CodeSubmitPage.tsx
@@ -101,6 +101,7 @@ const WrapButton = styled.div`
   display: flex;
   justify-content: center;
   margin: 200px 0px 100px 0px;
+  //푸터고정 = calc (뷰크기(vh) - (헤더를 제외한 내부콘텐츠 및 마진 + 푸터))
   min-height: calc(100vh - 744px);
 
   @media ${({ theme }) => theme.size.tablet} {


### PR DESCRIPTION
https://github.com/mju-likelion/inception/assets/81896174/bf7fd646-4060-42a4-80c8-15492bf56c98

이슈
- 디바이스의 세로 길이가 콘텐츠의 전체길이보다 더 길 때, 푸터가 고정되지 않았던 이슈

해결방법 
-  높이(height)에 calc() 메서드를 사용하여 ‘뷰 높이(vh) – 헤더를 제외한 나머지 공간’을 입력하여 푸터가 하단에 고정되도록 했습니다.