### PR TITLE
이슈 hotfix 

### DIFF
--- a/src/component/@share/atom/ButtonSmall.tsx
+++ b/src/component/@share/atom/ButtonSmall.tsx
@@ -7,6 +7,8 @@ interface Props {
   copyContent?: string;
   onClick?: () => void;
   onCopy?: (copyResult: ToastStatus) => void;
+  isDisabled?: boolean;
+  //다른 디바이스에서 일정 수정을 누를 경우 로그인 페이지에서 기존 유저로 로그인이 되는 것이 아닌, 신규 유저로 등록되는 버그를 막기 위하여 임의의 props 하나를 추가하였습니다.
 }
 
 export const ButtonSmall = ({
@@ -14,6 +16,7 @@ export const ButtonSmall = ({
   copyContent,
   onClick,
   onCopy,
+  isDisabled,
 }: PropsWithChildren<Props>) => {
   const handleCopy = (copyResult: ToastStatus) => {
     onCopy && onCopy(copyResult);
@@ -28,7 +31,9 @@ export const ButtonSmall = ({
       <Button>{children}</Button>
     </CopyToClipboard>
   ) : (
-    <Button onClick={onClick}>{children}</Button>
+    <Button onClick={onClick} disabled={isDisabled}>
+      {children}
+    </Button>
   );
 };
 
@@ -51,6 +56,12 @@ const Button = styled.button`
   &:active {
     background-color: ${({ theme }) => theme.colors.gray4};
     color: ${({ theme }) => theme.colors.gray2};
+    border: none;
+  }
+
+  &:disabled {
+    background-color: ${({ theme }) => theme.colors.gray5};
+    color: ${({ theme }) => theme.colors.gray3};
     border: none;
   }
 `;

--- a/src/component/@share/molecules/TitleBox.tsx
+++ b/src/component/@share/molecules/TitleBox.tsx
@@ -14,13 +14,13 @@ export const TitleBox = ({
   title,
   content,
   defaultColor = 'black',
-  total = 3,
+  total,
   step,
 }: TitleBoxProps) => {
   return (
     <Container title={title}>
       {step ? (
-        <ProgressBar total={total} step={step} />
+        <ProgressBar total={total ? total : 3} step={step} />
       ) : (
         <Title $color={defaultColor}>{title}</Title>
       )}

--- a/src/component/@share/template/LoginMasterTemplate.tsx
+++ b/src/component/@share/template/LoginMasterTemplate.tsx
@@ -6,12 +6,18 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilState, useResetRecoilState } from 'recoil';
 import { signUpNickname, signUpPassword } from '@/store/atoms/Login';
+
 interface Props {
   buttonClick: () => void;
   isDateOnly?: boolean;
+  token: string;
 }
 
-export const LoginMasterTemplate = ({ buttonClick, isDateOnly }: Props) => {
+export const LoginMasterTemplate = ({
+  buttonClick,
+  isDateOnly,
+  token,
+}: Props) => {
   const [nicknameValue, setNicknameValue] = useRecoilState(signUpNickname);
   const [passwordValue, setPasswordValue] = useRecoilState(signUpPassword);
   const [isButtonInactive, setIsButtonInactive] = useState(true);
@@ -32,6 +38,10 @@ export const LoginMasterTemplate = ({ buttonClick, isDateOnly }: Props) => {
   }, [nicknameValue, passwordValue]);
 
   useEffect(() => {
+    // if (token) {
+    //   //이미 제출한 유저라면
+    //   buttonClick();
+    // }
     return () => {
       resetNickname();
       resetPassword();
@@ -62,7 +72,8 @@ export const LoginMasterTemplate = ({ buttonClick, isDateOnly }: Props) => {
       <WrapUpperContents>
         <TitleBox
           total={isDateOnly ? 2 : 3}
-          step={isDateOnly ? 2 : 3}
+          step={token || isDateOnly ? 2 : 3}
+          //토큰이 있거나 날짜만 고르는 경우는 로그인 페이지가 2번째 스텝(물론 둘 다 있을 경우는 1번째 스텝이지만, AppointmentStepPage에서 modifier로직에 따라 step을 2로 고정)
           title=""
           content={'본인 확인을 위한 임시 닉네임과 비밀번호를 입력해주세요'}
         />

--- a/src/component/@share/template/LoginMasterTemplate.tsx
+++ b/src/component/@share/template/LoginMasterTemplate.tsx
@@ -38,10 +38,10 @@ export const LoginMasterTemplate = ({
   }, [nicknameValue, passwordValue]);
 
   useEffect(() => {
-    // if (token) {
-    //   //이미 제출한 유저라면
-    //   buttonClick();
-    // }
+    if (token) {
+      window.confirm('이미 제출한 기록이 있으므로 결과창으로 이동합니다.') &&
+        navigate(1);
+    }
     return () => {
       resetNickname();
       resetPassword();
@@ -65,7 +65,7 @@ export const LoginMasterTemplate = ({
     }
   };
 
-  const onClick = (tab: string) => {};
+  // const onClick = (tab: string) => {}; 누가 작성했는지는 모르겠지만, 우선 주석 처리 해놓겠숩니당
 
   return (
     <WrapContents>

--- a/src/component/@share/template/PossibleDateTemplate.tsx
+++ b/src/component/@share/template/PossibleDateTemplate.tsx
@@ -16,13 +16,29 @@ interface Props {
   prevCalendarDataExist: boolean;
   selectableDates?: string[];
   isDateOnly?: boolean;
+  token?: string;
 }
+
+export const getProgressBarTotalLength = (
+  isDateOnly?: boolean,
+  token?: string
+) => {
+  if (token && isDateOnly)
+    //제출한적도 있고, 시간 선택을 안할 경우 총길이는 1
+    return 1;
+  else if (token || isDateOnly)
+    //둘 다 해당 되는것은 아니지만 하나는 해당 되는 경우 총 길이는 2
+    return 2;
+  else return 3;
+  //모두 아니라면 총 길이는 3
+};
 
 export const PossibleDateTemplate = ({
   buttonClick,
   prevCalendarDataExist,
   selectableDates,
   isDateOnly,
+  token,
 }: Props) => {
   const [isActiveButton, setIsActiveButton] = useState(true);
   const calendarData = useRecoilValue(calendarState);
@@ -56,7 +72,10 @@ export const PossibleDateTemplate = ({
   return (
     <Wrapper>
       <Header>
-        <ProgressBar total={isDateOnly ? 2 : 3} step={1} />
+        <ProgressBar
+          total={getProgressBarTotalLength(isDateOnly, token)}
+          step={1}
+        />
         <Body $color="gray1">가능한 날짜들을 선택해주세요.</Body>
       </Header>
       <Content>

--- a/src/component/@share/template/PossibleTimeTemplate.tsx
+++ b/src/component/@share/template/PossibleTimeTemplate.tsx
@@ -11,12 +11,15 @@ interface Props {
   buttonClick: () => void;
   startTime: string;
   endTime: string;
+  token?: string;
+  //한번이라도 제출했으면 로그인 넘어가니까 토탈이 2입니다
 }
 
 export const PossibleTimeTemplate = ({
   buttonClick,
   startTime,
   endTime,
+  token,
 }: Props) => {
   const [isActive, setIsActive] = useState(true);
   const [isMouseDown, setIsMouseDown] = useRecoilState(isMouseDownState);
@@ -29,7 +32,11 @@ export const PossibleTimeTemplate = ({
     <TimePageBlock onMouseUp={mouseUp} onTouchEnd={mouseUp}>
       <ContentBlock>
         <TitleBoxBlock>
-          <TitleBox content="가능한 시간들을 선택해주세요" step={2} />
+          <TitleBox
+            content="가능한 시간들을 선택해주세요"
+            step={2}
+            total={token ? 2 : 3}
+          />
         </TitleBoxBlock>
         {startTime ? (
           <TimeBox

--- a/src/pages/AppointmentStepPage.tsx
+++ b/src/pages/AppointmentStepPage.tsx
@@ -104,7 +104,7 @@ export const AppointmentStepPage = () => {
     navigate(`/result?code=${params.code}`);
   };
 
-  const modifyUser = async (token: string) => {
+  const modifySceduleByToken = async (token: string) => {
     const res = await modifySchedule(token, params.code ?? '', {
       dates: selectedDates,
     });
@@ -123,7 +123,7 @@ export const AppointmentStepPage = () => {
     if (step === '3') {
       prevCalendarDataExist.current = false;
       if (token) {
-        modifyUser(token);
+        modifySceduleByToken(token);
         //step 3에서 토큰이 이미 있다면, 이건 수정
       }
       requestCreateUser();
@@ -131,10 +131,10 @@ export const AppointmentStepPage = () => {
       prevCalendarDataExist.current = true;
 
       if (step === '2' && token) {
-        modifyUser(token);
+        modifySceduleByToken(token);
       } else {
         if (token && roomInfo?.dateOnly) {
-          modifyUser(token);
+          modifySceduleByToken(token);
           //이미 제출했고, 날짜만 지정한 상태에서 다시 1단계에 입장한다면 시간 수정도 로그인도 불필요하므로 바로 결과창으로 라우팅
         }
         roomInfo?.dateOnly

--- a/src/pages/AppointmentStepPage.tsx
+++ b/src/pages/AppointmentStepPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo, useRef } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { useSearchParams, useNavigate, useParams } from 'react-router-dom';
 import { TabBar } from '@/component/@share';
 import {
@@ -77,9 +77,9 @@ export const AppointmentStepPage = () => {
     (async () => {
       const res = await viewRoom({ id: params.code ?? '' });
       setRoomInfo(res);
-
+      const token = localStorage.getItem((params.code ?? '') + 'token');
       window.addEventListener('beforeunload', preventRefresh);
-      if (step === '2' || step === '3') {
+      if (!token && (step === '2' || step === '3')) {
         navigate(`/appointment/${params.code}?step=1`);
       }
     })();
@@ -96,7 +96,10 @@ export const AppointmentStepPage = () => {
       dateOnly: roomInfo?.dateOnly ?? !!roomInfo?.dateOnly,
       dates: selectedDates,
     });
-    localStorage.setItem('token', res?.data.accessToken ?? '');
+    localStorage.setItem(
+      (params.code ?? '') + 'token',
+      res?.data.accessToken ?? ''
+    );
     navigate(`/result?code=${params.code}`);
   };
 
@@ -115,7 +118,7 @@ export const AppointmentStepPage = () => {
   };
 
   const handleButtonClick = () => {
-    const token = localStorage.getItem('token');
+    const token = localStorage.getItem((params.code ?? '') + 'token');
     if (step === '3') {
       prevCalendarDataExist.current = false;
       requestCreateUser();

--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -21,6 +21,8 @@ export const ResultPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const code = new URLSearchParams(location.search).get('code');
+  const token = localStorage.getItem((code ?? '') + 'token');
+  //disabled상태를 판단하기 위한 로컬스토로지 토큰을 가져옵니다.
 
   // 약속 정보
   const [appointmentData, setAppointmentData] = useRecoilState(
@@ -109,7 +111,9 @@ export const ResultPage = () => {
               fetchMostSelectedTimeForDate={fetchMostSelectedTimeForDate}
             />
             <GridFooter>
-              <ButtonSmall onClick={navigateModifyPage}>일정 수정</ButtonSmall>
+              <ButtonSmall onClick={navigateModifyPage} isDisabled={!!token}>
+                일정 수정
+              </ButtonSmall>
             </GridFooter>
             <InformationBlock>
               <Information

--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -111,7 +111,7 @@ export const ResultPage = () => {
               fetchMostSelectedTimeForDate={fetchMostSelectedTimeForDate}
             />
             <GridFooter>
-              <ButtonSmall onClick={navigateModifyPage} isDisabled={!!token}>
+              <ButtonSmall onClick={navigateModifyPage} isDisabled={!token}>
                 일정 수정
               </ButtonSmall>
             </GridFooter>

--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -104,7 +104,7 @@ export const ResultPage = () => {
         <ResultPageBlock>
           <ContentBlock>
             <TitleBoxBlock>
-              <TitleBox title={title} content={subTitle} />
+              <TitleBox title={title} content={subTitle} total={3} />
             </TitleBoxBlock>
             <Calendar
               viewType="result"


### PR DESCRIPTION
1. 기존 로직은 모든 약속방에서 동일한 key를 가진채 토큰을 관리하기에 식별이 되지 않았던 문제를 방코드 + token(String)으로 식별할 수 있게 수정하였습니다.
2. 기존 로직은 데이터 유지를 위해서 step2,3 일경우 1로 강제 라우팅하여 결과페이지에서 뒤로가기를 한 후에 앞으로가기가 활성화 되지 않았던 문제를 (step 1 으로 강제 라우팅되므로 hsitory 부재) token의 존재 조건을 추가하여 한 번이라도 등록한 유저는 step 강제 라우팅을 제거하는 방식으로 해결했습니다.
3. small button에 isDisabled props가 추가 됩니다. (현재 다른 디바이스에서 유저 식별이 불가하기에 한번이라도 제출하지 않아서 토큰이 없는 유저는 일정 수정 버튼이 disabled)
4. dateonly와 token의 여부에 따라서 progress bar가 핸들링 됩니다.
* case1 : 아무것도 없으면 3
* case2 : 제출한 적 없고 날짜만이면 2
* case3 : 제출한적 있는데 날짜만없어도 2
* case3 : 제출한 적도 있고 날짜만이면 1

