### PR TITLE
현재 달보다 이후의 달을 선택 가능할 때 캘린더가 안보이는 현상 수정

### DIFF
--- a/src/component/@share/template/LoginMasterTemplate.tsx
+++ b/src/component/@share/template/LoginMasterTemplate.tsx
@@ -3,7 +3,6 @@ import { TitleBox } from '@/component/@share/molecules';
 import { Input } from '@/component/@share/atom';
 import { ButtonLarge } from '@/component/@share/atom';
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useRecoilState, useResetRecoilState } from 'recoil';
 import { signUpNickname, signUpPassword } from '@/store/atoms/Login';
 interface Props {
@@ -17,8 +16,6 @@ export const LoginMasterTemplate = ({ buttonClick, isDateOnly }: Props) => {
   const [isButtonInactive, setIsButtonInactive] = useState(true);
   const resetNickname = useResetRecoilState(signUpNickname);
   const resetPassword = useResetRecoilState(signUpPassword);
-
-  const navigate = useNavigate();
 
   const onChangeNickname = (event: React.ChangeEvent<HTMLInputElement>) => {
     setNicknameValue(event.target.value);
@@ -54,8 +51,6 @@ export const LoginMasterTemplate = ({ buttonClick, isDateOnly }: Props) => {
       buttonClick();
     }
   };
-
-  const onClick = (tab: string) => {};
 
   return (
     <WrapContents>

--- a/src/component/@share/template/PossibleDateTemplate.tsx
+++ b/src/component/@share/template/PossibleDateTemplate.tsx
@@ -9,8 +9,7 @@ import { calendarState } from '@/store';
 import { useRecoilValue } from 'recoil';
 import { useState, useEffect } from 'react';
 import { useRecoilState } from 'recoil';
-import { dateListState, timeTableState } from '@/store';
-import { CalendarData } from '@/types';
+import { dateListState } from '@/store';
 interface Props {
   buttonClick: () => void;
   prevCalendarDataExist: boolean;

--- a/src/component/calendar/organisms/Calendar.tsx
+++ b/src/component/calendar/organisms/Calendar.tsx
@@ -372,14 +372,20 @@ const ResultMode = ({
   };
 
   useEffect(() => {
-    setCalendar(
-      getCalendarData(
-        dateRange.minDate[0],
-        dateRange.minDate[1],
-        'result',
-        calendarData
-      )
+    const calendar = getCalendarData(
+      dateRange.minDate[0],
+      dateRange.minDate[1],
+      'result',
+      calendarData
     );
+    setCalendar(calendar);
+
+    // currentMonth가 선택가능한 날짜의 월보다 작을 때 currentMonth 업데이트
+    const currentMonth = currentDate.join('-');
+    const calendarMonth = calendar.map((item) => item.date)[0].slice(0, 7);
+    if (new Date(currentMonth) < new Date(calendarMonth)) {
+      setCurrentDate(calendarMonth.split('-'));
+    }
   }, [dateRange, calendarData]);
 
   useEffect(() => {

--- a/src/pages/AppointmentStepPage.tsx
+++ b/src/pages/AppointmentStepPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo, useRef } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { useSearchParams, useNavigate, useParams } from 'react-router-dom';
 import { TabBar } from '@/component/@share';
 import {


### PR DESCRIPTION
## [이슈 노션 ](https://www.notion.so/likelion-11th/8e5fb4ecc3704da5a8dd0b20615e9adc)

# 원인
currentDate는 현재 캘린더가 표시해야할 월 정보를 가지고 있습니다.
결과 페이지에선 현재 보여줄 캘린더 값이 없을 때 기본 값으로 현재 날짜를 보여줍니다.
(ex: 현재 2023년 8월이면 2023년 8월 캘린더를 보여줌)

이때, 서버를 통해 가져온 캘린더가 currentDate보다 미래의 값을 가질 때 (여기선 9월이라 가정) currentDate는 8월인데 캘린더는 9월의 값만 가지고 있으니 출력할 캘린더 정보가 없어 빈 값을 렌더링 하고 있었습니다.

# 조치
서버를 통해 받아온 캘린더 정보로 캘린더 UI를 업데이트 할 때 currentDate와 서버 데이터와 비교해 currentDate값이 더 작다면 서버의 값으로 currentDate를 업데이트 하였습니다.